### PR TITLE
Fix scope of timeunit declaration

### DIFF
--- a/tb/tb_dummy_memory.sv
+++ b/tb/tb_dummy_memory.sv
@@ -15,8 +15,6 @@
  * Dummy memory transaction.
  */
 
-timeunit 1ps;
-timeprecision 1ps;
 
 module tb_dummy_memory
 #(
@@ -35,6 +33,9 @@ module tb_dummy_memory
   input  logic                enable_i,
   hwpe_stream_intf_tcdm.slave tcdm [MP-1:0]
 );
+
+  timeunit 1ps;
+  timeprecision 1ps;
 
   logic [MEMORY_SIZE-1:0][31:0] memory;
   int cnt = 0;

--- a/tb/tb_hwpe_stream_receiver.sv
+++ b/tb/tb_hwpe_stream_receiver.sv
@@ -16,8 +16,6 @@
  * of random
  */
 
-timeunit 1ns;
-timeprecision 1ps;
 
 module tb_hwpe_stream_receiver
 #(
@@ -33,6 +31,9 @@ module tb_hwpe_stream_receiver
   input  logic                 enable_i,
   hwpe_stream_intf_stream.sink data_i
 );
+
+  timeunit 1ns;
+  timeprecision 1ps;
 
   always
   begin

--- a/tb/tb_hwpe_stream_reservoir.sv
+++ b/tb/tb_hwpe_stream_reservoir.sv
@@ -16,8 +16,6 @@
  * of random
  */
 
-timeunit 1ns;
-timeprecision 1ps;
 
 import hwpe_stream_package::*;
 
@@ -41,6 +39,9 @@ module tb_hwpe_stream_reservoir
   input  logic                   enable_i,
   hwpe_stream_intf_stream.source data_o
 );
+
+  timeunit 1ns;
+  timeprecision 1ps;
 
   logic [RESERVOIR_SIZE-1:0][DATA_WIDTH-1:0]   reservoir;
   logic [RESERVOIR_SIZE-1:0][DATA_WIDTH/8-1:0] reservoir_strb;

--- a/tb/tb_hwpe_stream_sink_realign.sv
+++ b/tb/tb_hwpe_stream_sink_realign.sv
@@ -15,12 +15,13 @@
  * This is a unit test for the hwpe stream sink realign module
  */
 
-timeunit 1ns;
-timeprecision 1ps;
 
 import hwpe_stream_package::*;
 
 module tb_hwpe_stream_sink_realign;
+
+  timeunit 1ns;
+  timeprecision 1ps;
 
   // parameters
   parameter PROB_STALL = 0.2;

--- a/tb/tb_hwpe_stream_source_realign.sv
+++ b/tb/tb_hwpe_stream_source_realign.sv
@@ -15,12 +15,13 @@
  * This is a unit test for the hwpe stream sink realign module
  */
 
-timeunit 1ns;
-timeprecision 1ps;
 
 import hwpe_stream_package::*;
 
 module tb_hwpe_stream_source_realign;
+
+  timeunit 1ns;
+  timeprecision 1ps;
 
   // parameters
   parameter PROB_STALL = 0.2;

--- a/tb/tb_hwpe_stream_source_realign_decoupled.sv
+++ b/tb/tb_hwpe_stream_source_realign_decoupled.sv
@@ -15,12 +15,13 @@
  * This is a unit test for the hwpe stream sink realign module
  */
 
-timeunit 1ns;
-timeprecision 1ps;
 
 import hwpe_stream_package::*;
 
 module tb_hwpe_stream_source_realign_decoupled;
+
+  timeunit 1ns;
+  timeprecision 1ps;
 
   // parameters
   parameter PROB_STALL_SOURCE = 0.05;


### PR DESCRIPTION
By putting the timeunit declaration outside of the module declaration it
affects the whole compilation unit. This breaks PULPissimo when trying
to use a different simulator.