### PR TITLE
Fix correct data capturing behaviour in the fence block

### DIFF
--- a/rtl/basic/hwpe_stream_fence.sv
+++ b/rtl/basic/hwpe_stream_fence.sv
@@ -78,7 +78,7 @@ module hwpe_stream_fence #(
           data_q[ii] <= '0;
         else if(clear_i)
           data_q[ii] <= '0;
-        else if(~(fence_state_d[ii] && fence_state_q[ii]))
+        else if(in_valid[ii] && ~fence_state_q[ii])
           data_q[ii] <= push_i[ii].data;
       end
 
@@ -88,7 +88,7 @@ module hwpe_stream_fence #(
           strb_q[ii] <= '0;
         else if(clear_i)
           strb_q[ii] <= '0;
-        else if(~(fence_state_d[ii] && fence_state_q[ii]))
+        else if(in_valid[ii] && ~fence_state_q[ii])
           strb_q[ii] <= push_i[ii].strb;
       end
 

--- a/rtl/basic/hwpe_stream_fence.sv
+++ b/rtl/basic/hwpe_stream_fence.sv
@@ -78,7 +78,7 @@ module hwpe_stream_fence #(
           data_q[ii] <= '0;
         else if(clear_i)
           data_q[ii] <= '0;
-        else if(fence_state_d[ii])
+        else if(~(fence_state_d[ii] && fence_state_q[ii]))
           data_q[ii] <= push_i[ii].data;
       end
 
@@ -88,7 +88,7 @@ module hwpe_stream_fence #(
           strb_q[ii] <= '0;
         else if(clear_i)
           strb_q[ii] <= '0;
-        else if(fence_state_d[ii])
+        else if(~(fence_state_d[ii] && fence_state_q[ii]))
           strb_q[ii] <= push_i[ii].strb;
       end
 


### PR DESCRIPTION
the data from the push stream was captured every cycle
fix description: the data is captured only if it was not yet captured before