### PR TITLE
Update dependencies and build order in Bender.yml, use non-deprecated clk_gating

### DIFF
--- a/Bender.yml
+++ b/Bender.yml
@@ -5,45 +5,54 @@ package:
     - "Gianna Paulin <pauling@iis.ee.ethz.ch>"
 
 dependencies:
-  tech_cells_generic: { git: "https://github.com/pulp-platform/tech_cells_generic.git", version: 0.1.6 }
+  tech_cells_generic: { git: "https://github.com/pulp-platform/tech_cells_generic.git", version: 0.2.2 }
 
 sources:
   - include_dirs:
       - rtl
     files:
-      - rtl/hwpe_stream_package.sv
+      # Source files grouped in levels. Files in level 0 have no dependencies on files in this
+      # package. Files in level 1 only depend on files in level 0, files in level 2 on files in
+      # levels 1 and 0, etc. Files within a level are ordered alphabetically.
+      # Level 0
       - rtl/hwpe_stream_interfaces.sv
+      - rtl/hwpe_stream_package.sv
+      # Level 1
       - rtl/basic/hwpe_stream_assign.sv
-      - rtl/basic/hwpe_stream_mux_static.sv
-      - rtl/basic/hwpe_stream_demux_static.sv
       - rtl/basic/hwpe_stream_buffer.sv
-      - rtl/basic/hwpe_stream_merge.sv
-      - rtl/basic/hwpe_stream_fence.sv
-      - rtl/basic/hwpe_stream_split.sv
-      - rtl/basic/hwpe_stream_serialize.sv
+      - rtl/basic/hwpe_stream_demux_static.sv
       - rtl/basic/hwpe_stream_deserialize.sv
-      - rtl/fifo/hwpe_stream_fifo_earlystall_sidech.sv
-      - rtl/fifo/hwpe_stream_fifo_earlystall.sv
-      - rtl/fifo/hwpe_stream_fifo_scm.sv
-      - rtl/fifo/hwpe_stream_fifo_scm_test_wrap.sv
-      - rtl/fifo/hwpe_stream_fifo_sidech.sv
-      - rtl/fifo/hwpe_stream_fifo.sv
+      - rtl/basic/hwpe_stream_fence.sv
+      - rtl/basic/hwpe_stream_merge.sv
+      - rtl/basic/hwpe_stream_mux_static.sv
+      - rtl/basic/hwpe_stream_serialize.sv
+      - rtl/basic/hwpe_stream_split.sv
       - rtl/fifo/hwpe_stream_fifo_ctrl.sv
+      - rtl/fifo/hwpe_stream_fifo_scm.sv
       - rtl/streamer/hwpe_stream_addressgen.sv
       - rtl/streamer/hwpe_stream_addressgen_v2.sv
       - rtl/streamer/hwpe_stream_addressgen_v3.sv
-      - rtl/streamer/hwpe_stream_strbgen.sv
-      - rtl/streamer/hwpe_stream_sink.sv
       - rtl/streamer/hwpe_stream_sink_realign.sv
-      - rtl/streamer/hwpe_stream_source.sv
       - rtl/streamer/hwpe_stream_source_realign.sv
+      - rtl/streamer/hwpe_stream_strbgen.sv
       - rtl/streamer/hwpe_stream_streamer_queue.sv
-      - rtl/tcdm/hwpe_stream_tcdm_fifo_load.sv
-      - rtl/tcdm/hwpe_stream_tcdm_fifo_load_sidech.sv
-      - rtl/tcdm/hwpe_stream_tcdm_fifo_store.sv
-      - rtl/tcdm/hwpe_stream_tcdm_fifo.sv
       - rtl/tcdm/hwpe_stream_tcdm_assign.sv
       - rtl/tcdm/hwpe_stream_tcdm_mux.sv
       - rtl/tcdm/hwpe_stream_tcdm_mux_static.sv
       - rtl/tcdm/hwpe_stream_tcdm_reorder.sv
       - rtl/tcdm/hwpe_stream_tcdm_reorder_static.sv
+      # Level 2
+      - rtl/fifo/hwpe_stream_fifo_earlystall.sv
+      - rtl/fifo/hwpe_stream_fifo_earlystall_sidech.sv
+      - rtl/fifo/hwpe_stream_fifo_scm_test_wrap.sv
+      - rtl/fifo/hwpe_stream_fifo_sidech.sv
+      # Level 3
+      - rtl/fifo/hwpe_stream_fifo.sv
+      - rtl/tcdm/hwpe_stream_tcdm_fifo_load_sidech.sv
+      # Level 4
+      - rtl/streamer/hwpe_stream_source.sv
+      - rtl/tcdm/hwpe_stream_tcdm_fifo.sv
+      - rtl/tcdm/hwpe_stream_tcdm_fifo_load.sv
+      - rtl/tcdm/hwpe_stream_tcdm_fifo_store.sv
+      # Level 5
+      - rtl/streamer/hwpe_stream_sink.sv

--- a/rtl/basic/hwpe_stream_buffer.sv
+++ b/rtl/basic/hwpe_stream_buffer.sv
@@ -37,7 +37,7 @@ module hwpe_stream_buffer #(
 
   logic clk_gated;
 
-  cluster_clock_gating i_cg (
+  tc_clk_gating i_cg (
     .clk_o     ( clk_gated             ),
     .en_i      ( pop_o.ready | clear_i ),
     .test_en_i ( test_mode_i           ),

--- a/rtl/basic/hwpe_stream_deserialize.sv
+++ b/rtl/basic/hwpe_stream_deserialize.sv
@@ -63,7 +63,7 @@ module hwpe_stream_deserialize #(
 
   logic [$clog2(NB_OUT_STREAMS)-1:0] stream_cnt_d, stream_cnt_q;
   logic [$clog2(CONTIG_LIMIT)-1:0]   contig_cnt_d, contig_cnt_q;
-logic stream_cnt_en;
+  logic stream_cnt_en;
   logic [NB_OUT_STREAMS-1:0]         pop_ready;
 
   // stream serialization

--- a/rtl/fifo/hwpe_stream_fifo_scm.sv
+++ b/rtl/fifo/hwpe_stream_fifo_scm.sv
@@ -61,7 +61,7 @@ module hwpe_stream_fifo_scm
     genvar x;
     genvar y;
 
-    cluster_clock_gating CG_WE_GLOBAL
+    tc_clk_gating CG_WE_GLOBAL
     (
         .clk_o(clk_int),
         .en_i(WriteEnable),
@@ -110,7 +110,7 @@ module hwpe_stream_fifo_scm
     generate
     for(x=0; x<NUM_WORDS; x++)
     begin : CG_CELL_WORD_ITER
-        cluster_clock_gating CG_Inst
+        tc_clk_gating CG_Inst
         (
             .clk_o(ClocksxC[x]),
             .en_i(WAddrOneHotxD[x]),

--- a/rtl/streamer/hwpe_stream_sink.sv
+++ b/rtl/streamer/hwpe_stream_sink.sv
@@ -169,7 +169,7 @@ module hwpe_stream_sink
 
   /* clock gating */
   assign clk_realign_en = flags_o.addressgen_flags.realign_flags.enable;
-  cluster_clock_gating i_realign_gating (
+  tc_clk_gating i_realign_gating (
     .clk_i     ( clk_i             ),
     .test_en_i ( test_mode_i       ),
     .en_i      ( clk_realign_en    ),

--- a/rtl/streamer/hwpe_stream_source_realign.sv
+++ b/rtl/streamer/hwpe_stream_source_realign.sv
@@ -112,7 +112,7 @@ module hwpe_stream_source_realign #(
   logic int_last_packet;
 
   /* clock gating */
-  cluster_clock_gating i_realign_gating (
+  tc_clk_gating i_realign_gating (
     .clk_i     ( clk_i         ),
     .test_en_i ( test_mode_i   ),
     .en_i      ( ctrl_i.enable ),


### PR DESCRIPTION
Hi @FrancescoConti,
I hope these changes make sense, please let me know if you have questions.
If possible, it would be great to have a release of this repository once merged, I believe `v1.6.4` could make sense.