### PR TITLE
Made strobe width of HWPE Stream Fifo a parameter

### DIFF
--- a/rtl/fifo/hwpe_stream_fifo.sv
+++ b/rtl/fifo/hwpe_stream_fifo.sv
@@ -67,6 +67,7 @@ import hwpe_stream_package::*;
 
 module hwpe_stream_fifo #(
   parameter int unsigned DATA_WIDTH = 32,
+  parameter int unsigned STRB_WIDTH = DATA_WIDTH / 8,
   parameter int unsigned FIFO_DEPTH = 8,
   parameter int unsigned LATCH_FIFO = 0,
   parameter int unsigned LATCH_FIFO_TEST_WRAP = 0
@@ -90,7 +91,7 @@ module hwpe_stream_fifo #(
 
   logic [ADDR_DEPTH-1:0] pop_pointer_q,  pop_pointer_d;
   logic [ADDR_DEPTH-1:0] push_pointer_q, push_pointer_d;
-  logic [DATA_WIDTH+DATA_WIDTH/8-1:0] fifo_registers[FIFO_DEPTH-1:0];
+  logic [DATA_WIDTH+STRB_WIDTH-1:0] fifo_registers[FIFO_DEPTH-1:0];
   integer       i;
 
   assign flags_o.empty = (cs == EMPTY) ? 1'b1 : 1'b0;
@@ -229,8 +230,8 @@ module hwpe_stream_fifo #(
     endcase
   end
 
-  logic [DATA_WIDTH+DATA_WIDTH/8-1:0] data_out_int;
-  logic [DATA_WIDTH+DATA_WIDTH/8-1:0] data_in_int;
+  logic [DATA_WIDTH+STRB_WIDTH-1:0] data_out_int;
+  logic [DATA_WIDTH+STRB_WIDTH-1:0] data_in_int;
 
   generate
     if(LATCH_FIFO == 0) begin : fifo_ff_gen
@@ -260,7 +261,7 @@ module hwpe_stream_fifo #(
 
       hwpe_stream_fifo_scm #(
         .ADDR_WIDTH ( ADDR_DEPTH                ),
-        .DATA_WIDTH ( DATA_WIDTH + DATA_WIDTH/8 )
+        .DATA_WIDTH ( DATA_WIDTH + STRB_WIDTH   )
       ) i_fifo_latch (
         .clk         ( clk_i                       ),
         .rst_n       ( rst_ni                      ),
@@ -279,7 +280,7 @@ module hwpe_stream_fifo #(
 
       hwpe_stream_fifo_scm_test_wrap #(
         .ADDR_WIDTH ( ADDR_DEPTH                ),
-        .DATA_WIDTH ( DATA_WIDTH + DATA_WIDTH/8 )
+        .DATA_WIDTH ( DATA_WIDTH + STRB_WIDTH   )
       ) i_fifo_latch (
         .clk ( clk_i ),
         .rst_n       ( rst_ni                      ),
@@ -300,7 +301,7 @@ module hwpe_stream_fifo #(
     end
   endgenerate
 
-  assign pop_o.data = (pop_o.valid == 1'b1) ? data_out_int[DATA_WIDTH+DATA_WIDTH/8-1:DATA_WIDTH/8] : '0;
-  assign pop_o.strb = (pop_o.valid == 1'b1) ? data_out_int[DATA_WIDTH/8-1:0] : '0;
+  assign pop_o.data = (pop_o.valid == 1'b1) ? data_out_int[DATA_WIDTH+STRB_WIDTH-1:STRB_WIDTH] : '0;
+  assign pop_o.strb = (pop_o.valid == 1'b1) ? data_out_int[STRB_WIDTH-1:0] : '0;
 
 endmodule // hwpe_stream_fifo


### PR DESCRIPTION
Simply moved all the strobe with calculation into a parameter so that it could be externally defined if needed.

This change is needed for redundant RedMulE as data size will be increased with parity bits while Strobe stays the same.