### PR TITLE
Redundancy Features

### DIFF
--- a/Bender.yml
+++ b/Bender.yml
@@ -6,6 +6,7 @@ package:
 
 dependencies:
   tech_cells_generic: { git: "https://github.com/pulp-platform/tech_cells_generic.git", version: 0.2.2 }
+  redundancy_cells:   { git: "git@github.com:Lynx005F/redundancy_cells.git", rev: bccb2a9151bf18cafb90b25f51a491bb0ded1997}
 
 sources:
   - include_dirs:

--- a/rtl/hwpe_stream_package.sv
+++ b/rtl/hwpe_stream_package.sv
@@ -53,8 +53,10 @@ package hwpe_stream_package;
     logic signed [31:0] d0_stride;  // former word_stride
     logic        [31:0] d1_len;     // former block_length
     logic signed [31:0] d1_stride;  // former line_stride
+    logic        [31:0] d2_len;     
     logic signed [31:0] d2_stride;  // former block_stride
-    logic         [1:0] dim_enable_1h;
+    logic signed [31:0] d3_stride;
+    logic         [2:0] dim_enable_1h;
   } ctrl_addressgen_v3_t;
 
   typedef struct packed {

--- a/rtl/streamer/hwpe_stream_addressgen_v3.sv
+++ b/rtl/streamer/hwpe_stream_addressgen_v3.sv
@@ -141,177 +141,183 @@
  *
  */
 
+`include "redundancy_cells/voters.svh"
 
 import hwpe_stream_package::*;
 
 module hwpe_stream_addressgen_v3
 #(
   parameter int unsigned TRANS_CNT  = 32,
-  parameter int unsigned CNT        = 32  // number of bits used within the internal counter
+  parameter int unsigned CNT        = 32,  // number of bits used within the internal counter
+  parameter int unsigned REP        = 1,   // number of replicas of the internal FSM, sensible are 1 or 3
 )
 (
   // global signals
-  input  logic                   clk_i,
-  input  logic                   rst_ni,
+  input  logic                            clk_i,
+  input  logic                            rst_ni,
   // local enable and clear
-  input  logic                   enable_i,
-  input  logic                   clear_i,
-  input  logic                   presample_i,
+  input  logic [REP-1:0]                  enable_i,
+  input  logic [REP-1:0]                  clear_i,
+  input  logic [REP-1:0]                  presample_i,
   // generated output address
   hwpe_stream_intf_stream.source addr_o,
   // control channel
-  input  ctrl_addressgen_v3_t    ctrl_i,
-  output flags_addressgen_v3_t   flags_o
+  input  ctrl_addressgen_v3_t [REP-1:0]   ctrl_i,
+  output flags_addressgen_v3_t [REP-1:0]  flags_o
 );
 
-  logic signed [31:0] d0_stride;
-  logic signed [31:0] d1_stride;
-  logic signed [31:0] d2_stride;
-  logic signed [31:0] d3_stride;
+  logic signed [REP-1:0][31:0] d0_stride;
+  logic signed [REP-1:0][31:0] d1_stride;
+  logic signed [REP-1:0][31:0] d2_stride;
+  logic signed [REP-1:0][31:0] d3_stride;
 
-  logic [31:0] gen_addr_int;
-  logic        done;
+  logic [REP-1:0][31:0] gen_addr_int;
+  logic [REP-1:0]       done_v;
 
-  logic [TRANS_CNT-1:0] overall_counter_d;
-  logic [CNT-1:0]       d0_counter_d;
-  logic [CNT-1:0]       d1_counter_d;
-  logic [CNT-1:0]       d2_counter_d;
-  logic [CNT-1:0]       d3_counter_d;
-  logic [31:0]          d0_addr_d;
-  logic [31:0]          d1_addr_d;
-  logic [31:0]          d2_addr_d;
-  logic [31:0]          d3_addr_d;
-  logic [TRANS_CNT-1:0] overall_counter_q;
-  logic [CNT-1:0]       d0_counter_q;
-  logic [CNT-1:0]       d1_counter_q;
-  logic [CNT-1:0]       d2_counter_q;
-  logic [CNT-1:0]       d3_counter_q;
-  logic [31:0]          d0_addr_q;
-  logic [31:0]          d1_addr_q;
-  logic [31:0]          d2_addr_q;
-  logic [31:0]          d3_addr_q;
+  logic [REP-1:0][TRANS_CNT-1:0] overall_counter_v, overall_counter_d, overall_counter_q;
+  logic [REP-1:0][CNT-1:0]       d0_counter_v, d0_counter_d, d0_counter_q;
+  logic [REP-1:0][CNT-1:0]       d1_counter_v, d1_counter_d, d1_counter_q;
+  logic [REP-1:0][CNT-1:0]       d2_counter_v, d2_counter_d, d2_counter_q;
+  logic [REP-1:0][CNT-1:0]       d3_counter_v, d3_counter_d, d3_counter_q;
+  logic [REP-1:0][31:0]          d0_addr_v, d0_addr_d, d0_addr_q;
+  logic [REP-1:0][31:0]          d1_addr_v, d1_addr_d, d1_addr_q;
+  logic [REP-1:0][31:0]          d2_addr_v, d2_addr_d, d2_addr_q;
+  logic [REP-1:0][31:0]          d3_addr_v, d3_addr_d, d3_addr_q;
+  logic [REP-1:0] addr_valid_v, addr_valid_d, addr_valid_q;
 
-  logic        addr_valid_d, addr_valid_q;
-
-  assign d0_stride   = $signed(ctrl_i.d0_stride);
-  assign d1_stride   = $signed(ctrl_i.d1_stride);
-  assign d2_stride   = $signed(ctrl_i.d2_stride);
-  assign d3_stride   = $signed(ctrl_i.d3_stride);
+  for (genvar r = 0; r < REP; r++) begin: gen_assign_stride
+    assign d0_stride[r]   = $signed(ctrl_i[r].d0_stride);
+    assign d1_stride[r]   = $signed(ctrl_i[r].d1_stride);
+    assign d2_stride[r]   = $signed(ctrl_i[r].d2_stride);
+    assign d3_stride[r]   = $signed(ctrl_i[r].d3_stride);
+  end
 
   // address generation
-  always_comb
-  begin : address_gen_counters_comb
-    d0_addr_d         = d0_addr_q;
-    d1_addr_d         = d1_addr_q;
-    d2_addr_d         = d2_addr_q;
-    d3_addr_d         = d3_addr_q;
-    d0_counter_d      = d0_counter_q;
-    d1_counter_d      = d1_counter_q;
-    d2_counter_d      = d2_counter_q;
-    d3_counter_d      = d3_counter_q;
-    overall_counter_d = overall_counter_q;
-    addr_valid_d      = addr_valid_q;
-    done = '0;
-    if(addr_o.ready) begin
-      if(overall_counter_q < ctrl_i.tot_len) begin
-        addr_valid_d = 1'b1;
-        if((d0_counter_q < ctrl_i.d0_len) || (ctrl_i.dim_enable_1h[0] == 1'b0)) begin
-          d0_addr_d    = d0_addr_q + d0_stride;
-          d0_counter_d = d0_counter_q + 1;
-        end
-        else if ((d1_counter_q < ctrl_i.d1_len) || (ctrl_i.dim_enable_1h[1] == 1'b0)) begin
-          d0_addr_d    = '0;
-          d1_addr_d    = d1_addr_q + d1_stride;
-          d0_counter_d = 1;
-          d1_counter_d = d1_counter_q + 1;
-        end
-        else if ((d2_counter_q < ctrl_i.d2_len) || (ctrl_i.dim_enable_1h[2] == 1'b0)) begin
-          d0_addr_d    = '0;
-          d1_addr_d    = '0;
-          d2_addr_d    = d2_addr_q + d2_stride;
-          d0_counter_d = 1;
-          d1_counter_d = 1;
-          d2_counter_d = d2_counter_q + 1;
-        end
-        else begin
-          d0_addr_d    = '0;
-          d1_addr_d    = '0;
-          d2_addr_d    = '0;
-          d3_addr_d    = d3_addr_q + d3_stride;
-          d0_counter_d = 1;
-          d1_counter_d = 1;
-          d2_counter_d = 1;
-          d3_counter_d = d3_counter_q + 1;
-        end
-        overall_counter_d = overall_counter_q + 1;
+  for (genvar r = 0; r < REP; r++) begin: gen_next_state
+    always_comb
+    begin : address_gen_counters_comb
+      d0_addr_v[r]         = d0_addr_q[r];
+      d1_addr_v[r]         = d1_addr_q[r];
+      d2_addr_v[r]         = d2_addr_q[r];
+      d3_addr_v[r]         = d3_addr_q[r];
+      d0_counter_v[r]      = d0_counter_q[r];
+      d1_counter_v[r]      = d1_counter_q[r];
+      d2_counter_v[r]      = d2_counter_q[r];
+      d3_counter_v[r]      = d3_counter_q[r];
+      overall_counter_v[r] = overall_counter_q[r];
+      addr_valid_v[r]      = addr_valid_q[r];
+      done_v = '0;
+      if (presample_i) begin
+        // If presample is set then this works as a reset on the address 0 and counters
+        // but different to a reset the address is valid
+        // Behaviour if presample is set for more than one cycle at the start is undefined!
+        d0_addr_v[r] = '0;
+        d0_counter_v[r] = '1;
+        overall_counter_v[r] = '1;
+        addr_valid_v[r] = 1'b1;
       end
       else begin
-        addr_valid_d = 1'b0;
-        done = 1'b1;
+        if(addr_o.ready) begin
+          if(overall_counter_q[r] < ctrl_i[r].tot_len) begin
+            addr_valid_v[r] = 1'b1;
+            if((d0_counter_q[r] < ctrl_i[r].d0_len) || (ctrl_i[r].dim_enable_1h[0] == 1'b0)) begin
+              d0_addr_v[r]    = d0_addr_q[r] + d0_stride;
+              d0_counter_v[r] = d0_counter_q[r] + 1;
+            end
+            else if ((d1_counter_q[r] < ctrl_i[r].d1_len) || (ctrl_i[r].dim_enable_1h[1] == 1'b0)) begin
+              d0_addr_v[r]    = '0;
+              d1_addr_v[r]    = d1_addr_q[r] + d1_stride;
+              d0_counter_v[r] = 1;
+              d1_counter_v[r] = d1_counter_q[r] + 1;
+            end
+            else if ((d2_counter_q[r] < ctrl_i[r].d2_len) || (ctrl_i[r].dim_enable_1h[2] == 1'b0)) begin
+              d0_addr_v[r]    = '0;
+              d1_addr_v[r]    = '0;
+              d2_addr_v[r]    = d2_addr_q[r] + d2_stride;
+              d0_counter_v[r] = 1;
+              d1_counter_v[r] = 1;
+              d2_counter_v[r] = d2_counter_q[r] + 1;
+            end
+            else begin
+              d0_addr_v[r]    = '0;
+              d1_addr_v[r]    = '0;
+              d2_addr_v[r]    = '0;
+              d3_addr_v[r]    = d3_addr_q[r] + d3_stride;
+              d0_counter_v[r] = 1;
+              d1_counter_v[r] = 1;
+              d2_counter_v[r] = 1;
+              d3_counter_v[r] = d3_counter_q[r] + 1;
+            end
+            overall_counter_v[r] = overall_counter_q[r] + 1;
+          end
+          else begin
+            addr_valid_v[r] = 1'b0;
+            done_v = 1'b1;
+          end
+        end
       end
-    end
   end
 
-  // address generation
-  always_ff @(posedge clk_i or negedge rst_ni)
-  begin : address_gen_counters_d0_ff
-    if (~rst_ni) begin
-      d0_addr_q <= '0;
-    end
-    else if (clear_i) begin
-      d0_addr_q <= '0;
-    end
-    else if (presample_i) begin
-      d0_addr_q <= '0;
-    end
-    else if (enable_i) begin
-      d0_addr_q <= d0_addr_d;
-    end
-  end
+  `VOTEXX(overall_counter_v, overall_counter_d);
+  `VOTEXX(d0_addr_v, d0_addr_d);
+  `VOTEXX(d1_addr_v, d1_addr_d);
+  `VOTEXX(d2_addr_v, d2_addr_d);
+  `VOTEXX(d3_addr_v, d3_addr_d);
+  `VOTEXX(d0_counter_v, d0_counter_d);
+  `VOTEXX(d1_counter_v, d1_counter_d);
+  `VOTEXX(d2_counter_v, d2_counter_d);
+  `VOTEXX(d3_counter_v, d3_counter_d);
+  `VOTEXX(addr_valid_v, addr_valid_d);
 
   always_ff @(posedge clk_i or negedge rst_ni)
   begin : address_gen_counters_ff
     if (~rst_ni) begin
-      d1_addr_q         <= '0;
-      d2_addr_q         <= '0;
-      d3_addr_q         <= '0;
-      d0_counter_q      <= '0;
-      d1_counter_q      <= 1;
-      d2_counter_q      <= 1;
-      d3_counter_q      <= 1;
-      overall_counter_q <= '0;
-      addr_valid_q      <= '0;
+      d0_addr_q[r]         <= '0;
+      d1_addr_q[r]         <= '0;
+      d2_addr_q[r]         <= '0;
+      d3_addr_q[r]         <= '0;
+      d0_counter_q[r]      <= 1;
+      d1_counter_q[r]      <= 1;
+      d2_counter_q[r]      <= 1;
+      d3_counter_q[r]      <= 1;
+      overall_counter_q[r] <= 1;
+      addr_valid_q[r]      <= '0;
     end
     else if (clear_i) begin
-      d1_addr_q         <= '0;
-      d2_addr_q         <= '0;
-      d3_addr_q         <= '0;
-      d0_counter_q      <= '0;
-      d1_counter_q      <= 1;
-      d2_counter_q      <= 1;
-      d3_counter_q      <= 1;
-      overall_counter_q <= '0;
-      addr_valid_q      <= '0;
+      d0_addr_q[r]         <= '0;
+      d1_addr_q[r]         <= '0;
+      d2_addr_q[r]         <= '0;
+      d3_addr_q[r]         <= '0;
+      d0_counter_q[r]      <= 1;
+      d1_counter_q[r]      <= 1;
+      d2_counter_q[r]      <= 1;
+      d3_counter_q[r]      <= 1;
+      overall_counter_q[r] <= 1;
+      addr_valid_q[r]      <= '0;
     end
     else if(enable_i) begin
-      d1_addr_q         <= d1_addr_d;
-      d2_addr_q         <= d2_addr_d;
-      d3_addr_q         <= d3_addr_d;
-      d0_counter_q      <= d0_counter_d;
-      d1_counter_q      <= d1_counter_d;
-      d2_counter_q      <= d2_counter_d;
-      d3_counter_q      <= d3_counter_d;
-      overall_counter_q <= overall_counter_d;
-      addr_valid_q      <= addr_valid_d;
+      d0_addr_q[r]         <= d0_addr_d[r];
+      d1_addr_q[r]         <= d1_addr_d[r];
+      d2_addr_q[r]         <= d2_addr_d[r];
+      d3_addr_q[r]         <= d3_addr_d[r];
+      d0_counter_q[r]      <= d0_counter_d[r];
+      d1_counter_q[r]      <= d1_counter_d[r];
+      d2_counter_q[r]      <= d2_counter_d[r];
+      d3_counter_q[r]      <= d3_counter_d[r];
+      overall_counter_q[r] <= overall_counter_d[r];
+      addr_valid_q[r]      <= addr_valid_d[r];
     end
   end
 
-  assign gen_addr_int = ctrl_i.base_addr + d3_addr_q + d2_addr_q + d1_addr_q + d0_addr_q;
+  // From here on out we have output logic that does not affect the next state 
+  // As such we do not need any redundancy or voters
+
+  assign gen_addr_int = ctrl_i[0].base_addr + d3_addr_q[0] + d2_addr_q[0] + d1_addr_q[0] + d0_addr_q[0];
 
   assign addr_o.data  = gen_addr_int;
   assign addr_o.strb  = '1;
-  assign addr_o.valid = addr_valid_q;
+  assign addr_o.valid = addr_valid_q[0];
 
-  assign flags_o.done = done;
+  assign flags_o.done = done_v[0];
 
 endmodule // hwpe_stream_addressgen_v3


### PR DESCRIPTION
PR with two features related to Redundancy in Accelerators.

1. Adding a 4th dimension to the addressgen v3.
For repeating memory accesses for repeated / redundant operations sometimes another dimension in the access pattern is necessary. This change allows that with minimal changes. Current programming of the address generator should still work, but it would make sense to check the most significant bit in `dim_enable_1h` to ensure the extra dimension is disabled by default.
Alternatively we could also merge a version that allows for parameterized n-dimensional access pattern (only really matters if compile does not optimize away unused dimensions): [N-Dimensional Address Generator](https://github.com/Lynx005F/hwpe-stream/commit/8a0c2e515f22979c628491e3033d0451843c15e2) but that version could use some more simplification.

2. Making the address generator parametizable redundant. 
Since the address generator is statefull, bitfilips in it could cause problems for all future fetches and not just a sigle fetch.
A single wrong fetch could always be detected or corrected elsewhere, but jumping specially 2x the usual distance could lead to all replicas of an element to be wrong.
This depends on redundancy_cells - voter macros which are not yet merged, until then this is a draft PR.

I know that loading data twice is subobtimal, possibly there are other ways to tell the HCI source / sink modules with ECC to output each data element twice and reduce memory load.

