### PR TITLE
Added 4th dimension to addressgen_v3.sv

### DIFF
--- a/rtl/hwpe_stream_package.sv
+++ b/rtl/hwpe_stream_package.sv
@@ -53,8 +53,10 @@ package hwpe_stream_package;
     logic signed [31:0] d0_stride;  // former word_stride
     logic        [31:0] d1_len;     // former block_length
     logic signed [31:0] d1_stride;  // former line_stride
+    logic        [31:0] d2_len;     
     logic signed [31:0] d2_stride;  // former block_stride
-    logic         [1:0] dim_enable_1h;
+    logic signed [31:0] d3_stride;
+    logic         [2:0] dim_enable_1h;
   } ctrl_addressgen_v3_t;
 
   typedef struct packed {

--- a/rtl/streamer/hwpe_stream_addressgen_v3.sv
+++ b/rtl/streamer/hwpe_stream_addressgen_v3.sv
@@ -147,7 +147,8 @@ import hwpe_stream_package::*;
 module hwpe_stream_addressgen_v3
 #(
   parameter int unsigned TRANS_CNT  = 32,
-  parameter int unsigned CNT        = 32  // number of bits used within the internal counter
+  parameter int unsigned CNT        = 32,    // number of bits used within the internal counter
+  parameter bit [2:0] DIM_ENABLE_1H = 3'b011 // Number of dimensions enabled on HW side
 )
 (
   // global signals
@@ -215,17 +216,17 @@ module hwpe_stream_addressgen_v3
     if(addr_o.ready) begin
       if(overall_counter_q < ctrl_i.tot_len) begin
         addr_valid_d = 1'b1;
-        if((d0_counter_q < ctrl_i.d0_len) || (ctrl_i.dim_enable_1h[0] == 1'b0)) begin
+        if((d0_counter_q < ctrl_i.d0_len) || (ctrl_i.dim_enable_1h[0] == 1'b0) || (DIM_ENABLE_1H[0] == 1'b0)) begin
           d0_addr_d    = d0_addr_q + d0_stride;
           d0_counter_d = d0_counter_q + 1;
         end
-        else if ((d1_counter_q < ctrl_i.d1_len) || (ctrl_i.dim_enable_1h[1] == 1'b0)) begin
+        else if ((d1_counter_q < ctrl_i.d1_len) || (ctrl_i.dim_enable_1h[1] == 1'b0) || (DIM_ENABLE_1H[1] == 1'b0)) begin
           d0_addr_d    = '0;
           d1_addr_d    = d1_addr_q + d1_stride;
           d0_counter_d = 1;
           d1_counter_d = d1_counter_q + 1;
         end
-        else if ((d2_counter_q < ctrl_i.d2_len) || (ctrl_i.dim_enable_1h[2] == 1'b0)) begin
+        else if ((d2_counter_q < ctrl_i.d2_len) || (ctrl_i.dim_enable_1h[2] == 1'b0) || (DIM_ENABLE_1H[2] == 1'b0)) begin
           d0_addr_d    = '0;
           d1_addr_d    = '0;
           d2_addr_d    = d2_addr_q + d2_stride;


### PR DESCRIPTION
In order to allow for more complex access patterns required in RedMulE with redundancy I need another 
dimension in the adress generator. This PR extends the existing `hwpe_stream_addressgen_v3` by another
len and addr counter for the 4th dimension.

Functionally the address generator otherwise stayed exactly the same, and I expect the counters for the extra
dimension to be optimised away if they are never used.

I had to increase the `dim_enable_1h` signal by one bit which with existing instantiations might now be undefined
and cause problems. If necessary I could also make a 4d version under a different name and add a parameter switch 
to the sink and source modules that instantiate the adress generator.

(If adding a new version, we could also use a [parametric N-dimensional one I wrote](https://github.com/Lynx005F/hwpe-stream/commit/7a86b8b4e6ae65dbfafc3d1b0e46ef7245414c79))