### PR TITLE
Add Modules that allow Fault Detection on Handshake and Data

### DIFF
--- a/Bender.yml
+++ b/Bender.yml
@@ -29,6 +29,8 @@ sources:
       - rtl/basic/hwpe_stream_split.sv
       - rtl/fifo/hwpe_stream_fifo_ctrl.sv
       - rtl/fifo/hwpe_stream_fifo_scm.sv
+      - rtl/parity/hwpe_stream_copy_sink.sv
+      - rtl/parity/hwpe_stream_copy_source.sv
       - rtl/streamer/hwpe_stream_addressgen.sv
       - rtl/streamer/hwpe_stream_addressgen_v2.sv
       - rtl/streamer/hwpe_stream_addressgen_v3.sv

--- a/rtl/hwpe_stream_package.sv
+++ b/rtl/hwpe_stream_package.sv
@@ -122,9 +122,10 @@ package hwpe_stream_package;
   } ctrl_serdes_t;
 
   typedef enum logic[1:0] {
-    COPY,    // Fully copy all signals of the origin
-    PARITY,  // Copy handshake and strobe, reduce bitwidth to strobe width and do bytewise parity
-    ZERO     // Copy handshake, set both data and strobe width to 1 and do not use them
-  } copy_type_t;
+    COPY,      // Fully copy all signals of the origin
+    PARITY,    // Copy handshake and strobe, reduce bitwidth to strobe width and do bytewise parity
+    STRB_ONLY, // Copy handshake and strobe, don't send data.
+    ZERO       // Copy handshake, set both data and strobe width to 1 and do not use them
+  } hwpe_copy_t;
 
 endpackage

--- a/rtl/hwpe_stream_package.sv
+++ b/rtl/hwpe_stream_package.sv
@@ -121,4 +121,10 @@ package hwpe_stream_package;
     logic [$clog2(NB_SERDES_STREAMS_MAX)-1:0] nb_contig_m1;
   } ctrl_serdes_t;
 
+  typedef enum logic[1:0] {
+    COPY,    // Fully copy all signals of the origin
+    PARITY,  // Copy handshake and strobe, reduce bitwidth to strobe width and do bytewise parity
+    ZERO     // Copy handshake, set both data and strobe width to 1 and do not use them
+  } copy_type_t;
+
 endpackage

--- a/rtl/parity/hwpe_stream_copy_sink.sv
+++ b/rtl/parity/hwpe_stream_copy_sink.sv
@@ -1,0 +1,93 @@
+/*
+ * hwpe_stream_copy_sink.sv
+ * Maurus Item <itemm@student.ethz.ch>
+ *
+ * Copyright (C) 2024-2024 ETH Zurich, University of Bologna
+ * Copyright and related rights are licensed under the Solderpad Hardware
+ * License, Version 0.51 (the "License"); you may not use this file except in
+ * compliance with the License.  You may obtain a copy of the License at
+ * http://solderpad.org/licenses/SHL-0.51. Unless required by applicable law
+ * or agreed to in writing, software, hardware and materials distributed under
+ * this License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+/**
+ * The **hwpe_stream_copy_sink** module is used to monitor an input normal
+ * stream `original_i` and compare it with a copy stream `copy_i`.
+ * Together with hwpe_stream_copy_source this allows for low area fault detection
+ * on HWPE streams by building a copy network that matches the original network.
+ *
+ * How "deep" the copy is can be set with the parameter COPY_TYPE.
+ * COPY_TYPE MUST match on connected sinks and sources!
+ *
+ * The available options are:
+ * - COPY:   Fully copy of everything.
+ *           DATA_WIDTH_COPY = DATA_WIDTH_ORIGINAL
+ *           STRB_WIDTH_COPY = STRB_WIDTH_ORIGINAL
+ * - PARITY: Reduction on the data width.
+ *           DATA_WIDTH_COPY = STRB_WIDTH_ORIGINAL <--- Notice it is STRB here!
+ *           STRB_WIDTH_COPY = STRB_WIDTH_ORIGINAL
+ * - ZERO:   No data or strobe information.
+ *           DATA_WIDTH_COPY = 1
+ *           STRB_WIDTH_COPY = 1
+ */
+
+
+import hwpe_stream_package::*;
+
+module hwpe_stream_copy_sink #(
+  parameter hwpe_stream_package::copy_type_t  COPY_TYPE = COPY,
+  parameter                     int unsigned DATA_WIDTH = 32,           // Data width before any modifications
+  parameter                     int unsigned STRB_WIDTH = DATA_WIDTH/8, // Strobe width before any modifications
+  parameter                            logic  DONT_CARE = 1             // Signal to use for don't care assignments
+) (
+  input logic                     clk_i,
+  input logic                     rst_ni,
+  hwpe_stream_intf_stream.monitor original_i,
+  hwpe_stream_intf_stream.sink    copy_i,
+  output logic                    fault_o
+);
+
+  logic fault, data_fault, strobe_fault, valid_fault;
+
+  // Assign handshake directly
+  assign copy_i.ready = original_i.ready;
+  assign valid_fault = copy_i.valid != original_i.valid;
+
+  // Assign strobe and data based on type
+  if (COPY_TYPE == COPY) begin
+    assign data_fault   = copy_i.data != original_i.data;
+    assign strobe_fault = copy_i.strb != original_i.strb;
+  end
+  else if (COPY_TYPE == PARITY) begin
+    // Compute parity localy for compare
+    logic [STRB_WIDTH-1:0] local_parity_data;
+    for (genvar i = 0; i < STRB_WIDTH; i++) begin
+      assign local_parity_data[i] = ^original_i.data[i * DATA_WIDTH/STRB_WIDTH +: DATA_WIDTH/STRB_WIDTH];
+    end
+
+    assign data_fault   = copy_i.data != local_parity_data;
+    assign strobe_fault = copy_i.strb != original_i.strb;
+  end
+  else if (COPY_TYPE == ZERO) begin
+    assign data_fault   = 1'b0;
+    assign strobe_fault = 1'b0;
+  end
+  else begin
+    $fatal(1, "Unsupported COPY_TYPE in hwpe_stream_copy_sink!\n");
+  end
+
+  assign fault = data_fault | strobe_fault | valid_fault;
+
+  // Register on fault detected to not make critical path longer
+  always_ff @(posedge clk_i or negedge rst_ni) begin
+    if (!rst_ni) begin
+      fault_o <= '0;
+    end else begin
+      fault_o <= fault;
+    end
+  end
+
+endmodule : hwpe_stream_copy_sink

--- a/rtl/parity/hwpe_stream_copy_sink.sv
+++ b/rtl/parity/hwpe_stream_copy_sink.sv
@@ -23,22 +23,25 @@
  * COPY_TYPE MUST match on connected sinks and sources!
  *
  * The available options are:
- * - COPY:   Fully copy of everything.
- *           DATA_WIDTH_COPY = DATA_WIDTH_ORIGINAL
- *           STRB_WIDTH_COPY = STRB_WIDTH_ORIGINAL
- * - PARITY: Reduction on the data width.
- *           DATA_WIDTH_COPY = STRB_WIDTH_ORIGINAL <--- Notice it is STRB here!
- *           STRB_WIDTH_COPY = STRB_WIDTH_ORIGINAL
- * - ZERO:   No data or strobe information.
- *           DATA_WIDTH_COPY = 1
- *           STRB_WIDTH_COPY = 1
+ * - COPY:      Fully copy of everything.
+ *              DATA_WIDTH_COPY = DATA_WIDTH_ORIGINAL
+ *              STRB_WIDTH_COPY = STRB_WIDTH_ORIGINAL
+ * - PARITY:    Reduction on the data width with parity per bit.
+ *              DATA_WIDTH_COPY = STRB_WIDTH_ORIGINAL <--- Notice it is STRB here!
+ *              STRB_WIDTH_COPY = STRB_WIDTH_ORIGINAL
+ * - STRB_ONLY: No data information.
+ *              DATA_WIDTH_COPY = 1
+ *              STRB_WIDTH_COPY = STRB_WIDTH_ORIGINAL
+ * - ZERO:      No data or strobe information.
+ *              DATA_WIDTH_COPY = 1
+ *              STRB_WIDTH_COPY = 1
  */
 
 
 import hwpe_stream_package::*;
 
 module hwpe_stream_copy_sink #(
-  parameter hwpe_stream_package::copy_type_t  COPY_TYPE = COPY,
+  parameter hwpe_stream_package::hwpe_copy_t  COPY_TYPE = COPY,
   parameter                     int unsigned DATA_WIDTH = 32,           // Data width before any modifications
   parameter                     int unsigned STRB_WIDTH = DATA_WIDTH/8, // Strobe width before any modifications
   parameter                            logic  DONT_CARE = 1             // Signal to use for don't care assignments
@@ -69,6 +72,10 @@ module hwpe_stream_copy_sink #(
     end
 
     assign data_fault   = copy_i.data != local_parity_data;
+    assign strobe_fault = copy_i.strb != original_i.strb;
+  end
+  else if (COPY_TYPE == STRB_ONLY) begin
+    assign data_fault   = 1'b0;
     assign strobe_fault = copy_i.strb != original_i.strb;
   end
   else if (COPY_TYPE == ZERO) begin

--- a/rtl/parity/hwpe_stream_copy_source.sv
+++ b/rtl/parity/hwpe_stream_copy_source.sv
@@ -23,21 +23,24 @@
  * COPY_TYPE MUST match on connected sinks and sources!
  *
  * The available options are:
- * - COPY:   Fully copy of everything.
- *           DATA_WIDTH_COPY = DATA_WIDTH_ORIGINAL
- *           STRB_WIDTH_COPY = STRB_WIDTH_ORIGINAL
- * - PARITY: Reduction on the data width.
- *           DATA_WIDTH_COPY = STRB_WIDTH_ORIGINAL <--- Notice it is STRB here!
- *           STRB_WIDTH_COPY = STRB_WIDTH_ORIGINAL
- * - ZERO:   No data or strobe information.
- *           DATA_WIDTH_COPY = 1
- *           STRB_WIDTH_COPY = 1
+ * - COPY:      Fully copy of everything.
+ *              DATA_WIDTH_COPY = DATA_WIDTH_ORIGINAL
+ *              STRB_WIDTH_COPY = STRB_WIDTH_ORIGINAL
+ * - PARITY:    Reduction on the data width with parity per bit.
+ *              DATA_WIDTH_COPY = STRB_WIDTH_ORIGINAL <--- Notice it is STRB here!
+ *              STRB_WIDTH_COPY = STRB_WIDTH_ORIGINAL
+ * - STRB_ONLY: No data information.
+ *              DATA_WIDTH_COPY = 1
+ *              STRB_WIDTH_COPY = STRB_WIDTH_ORIGINAL
+ * - ZERO:      No data or strobe information.
+ *              DATA_WIDTH_COPY = 1
+ *              STRB_WIDTH_COPY = 1
  */
 
 import hwpe_stream_package::*;
 
 module hwpe_stream_copy_source #(
-  parameter hwpe_stream_package::copy_type_t  COPY_TYPE = COPY,
+  parameter hwpe_stream_package::hwpe_copy_t  COPY_TYPE = COPY,
   parameter                     int unsigned DATA_WIDTH = 32,           // Data width before any modifications
   parameter                     int unsigned STRB_WIDTH = DATA_WIDTH/8, // Strobe width before any modifications
   parameter                            logic  DONT_CARE = 1             // Signal to use for don't care assignments
@@ -63,6 +66,10 @@ module hwpe_stream_copy_source #(
     for (genvar i = 0; i < STRB_WIDTH ; i++) begin
       assign copy_o.data[i]  = ^original_i.data[i * DATA_WIDTH/STRB_WIDTH +: DATA_WIDTH/STRB_WIDTH];
     end
+    assign copy_o.strb = original_i.strb;
+  end
+  else if (COPY_TYPE == STRB_ONLY) begin
+    assign copy_o.data = DONT_CARE;
     assign copy_o.strb = original_i.strb;
   end
   else if (COPY_TYPE == ZERO) begin

--- a/rtl/parity/hwpe_stream_copy_source.sv
+++ b/rtl/parity/hwpe_stream_copy_source.sv
@@ -1,0 +1,86 @@
+/*
+ * hwpe_stream_copy_source.sv
+ * Maurus Item <itemm@student.ethz.ch>
+ *
+ * Copyright (C) 2024-2024 ETH Zurich, University of Bologna
+ * Copyright and related rights are licensed under the Solderpad Hardware
+ * License, Version 0.51 (the "License"); you may not use this file except in
+ * compliance with the License.  You may obtain a copy of the License at
+ * http://solderpad.org/licenses/SHL-0.51. Unless required by applicable law
+ * or agreed to in writing, software, hardware and materials distributed under
+ * this License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+/**
+ * The **hwpe_stream_copy_source** module is used to monitor an input normal
+ * stream `original_i` and copy it to an output stream `copy_o`.
+ * Together with hwpe_stream_copy_sink this allows for low area fault detection on
+ * HWPE streams by building a copy network that matches the original network.
+ *
+ * How "deep" the copy is can be set with the parameter COPY_TYPE.
+ * COPY_TYPE MUST match on connected sinks and sources!
+ *
+ * The available options are:
+ * - COPY:   Fully copy of everything.
+ *           DATA_WIDTH_COPY = DATA_WIDTH_ORIGINAL
+ *           STRB_WIDTH_COPY = STRB_WIDTH_ORIGINAL
+ * - PARITY: Reduction on the data width.
+ *           DATA_WIDTH_COPY = STRB_WIDTH_ORIGINAL <--- Notice it is STRB here!
+ *           STRB_WIDTH_COPY = STRB_WIDTH_ORIGINAL
+ * - ZERO:   No data or strobe information.
+ *           DATA_WIDTH_COPY = 1
+ *           STRB_WIDTH_COPY = 1
+ */
+
+import hwpe_stream_package::*;
+
+module hwpe_stream_copy_source #(
+  parameter hwpe_stream_package::copy_type_t  COPY_TYPE = COPY,
+  parameter                     int unsigned DATA_WIDTH = 32,           // Data width before any modifications
+  parameter                     int unsigned STRB_WIDTH = DATA_WIDTH/8, // Strobe width before any modifications
+  parameter                            logic  DONT_CARE = 1             // Signal to use for don't care assignments
+) (
+  input logic                     clk_i,
+  input logic                     rst_ni,
+  hwpe_stream_intf_stream.monitor original_i,
+  hwpe_stream_intf_stream.source  copy_o,
+  output logic                    fault_o
+);
+  logic ready_fault;
+
+  // Assign handshake directly
+  assign copy_o.valid = original_i.valid;
+  assign ready_fault = original_i.ready != copy_o.ready;
+
+  // Assign strobe and data based on type
+  if (COPY_TYPE == COPY) begin
+    assign copy_o.data = original_i.data;
+    assign copy_o.strb = original_i.strb;
+  end
+  else if (COPY_TYPE == PARITY) begin
+    for (genvar i = 0; i < STRB_WIDTH ; i++) begin
+      assign copy_o.data[i]  = ^original_i.data[i * DATA_WIDTH/STRB_WIDTH +: DATA_WIDTH/STRB_WIDTH];
+    end
+    assign copy_o.strb = original_i.strb;
+  end
+  else if (COPY_TYPE == ZERO) begin
+    assign copy_o.data = DONT_CARE;
+    assign copy_o.strb = DONT_CARE;
+  end
+  else begin
+        $fatal(1, "Unsupported COPY_TYPE in hwpe_stream_copy_source!\n");
+  end
+
+  // Register on fault detected to not make critical path longer
+  always_ff @(posedge clk_i or negedge rst_ni) begin
+    if (!rst_ni) begin
+      fault_o <= '0;
+    end
+    else begin
+      fault_o <= ready_fault;
+    end
+  end
+
+endmodule : hwpe_stream_copy_source

--- a/src_files.yml
+++ b/src_files.yml
@@ -24,6 +24,8 @@ hwpe-stream:
     rtl/fifo/hwpe_stream_fifo_sidech.sv,
     rtl/fifo/hwpe_stream_fifo.sv,
     rtl/fifo/hwpe_stream_fifo_ctrl.sv,
+    rtl/parity/hwpe_stream_copy_sink.sv,
+    rtl/parity/hwpe_stream_copy_source.sv,
     rtl/streamer/hwpe_stream_addressgen.sv,
     rtl/streamer/hwpe_stream_addressgen_v2.sv,
     rtl/streamer/hwpe_stream_addressgen_v3.sv,


### PR DESCRIPTION
Add some Voter-Source and Voter-Sink modules that allow the creation of HWPE Structures that "copy" the main structure and
thus allow fault detection. High level Idea:

![image](https://github.com/pulp-platform/hwpe-stream/assets/45683914/6cbf6703-47ec-4f6a-8c3e-f9fd73c0c1b2)

This implements three varieties of Voter-Source and Voter-Sink modules:
- **"Copy"** mirror everything over e.g. for when there are interleaved combinatorial elements
- **"Parity"** keep one parity bit per byte and are otherwise the same, for when there needs to be fault detection also on the datapath
- **"Zero"** do not transfer any data and only have a Handshake, for when the data is otherwise protected e.g. with ECC

It is possible to convert in between the types by "double stacking" them e.g.
![image](https://github.com/pulp-platform/hwpe-stream/assets/45683914/d0cc8a31-a239-4cff-a77c-59931baa0f89)

Note that just connecthing both sides to the original Network does not result in good fault detection if there are no other operations in between:
![image](https://github.com/pulp-platform/hwpe-stream/assets/45683914/f83c8edc-d941-450b-986f-ed757f84678a)

Currently the following sizing can be used for elements:
```
COPY_DATA_WIDTH = NORMAL_STRB_WIDTH
COPY_STRB_WIDTH = NORMAL_STRB_WIDTH

PARITY_DATA_WIDTH = NORMAL_STRB_WIDTH
PARITY_STRB_WIDTH = NORMAL_STRB_WIDTH

ZERO_DATA_WIDTH = 1
ZERO_STRB_WIDTH = NORMAL_STRB_WIDTH
```

For these sizes, the modules are complete, but maybe it is possible to further reduce the sizes:
- Do any of the existing modules do some kind of operation on Strobe and Data or just pass them through?

Draft until answered

Same principles can also be used to have fault detection on HCI, currently WIP:
https://github.com/Lynx005F/hci/tree/itemm/parity_canary