### PR TITLE
Fix incorrect behavior of hwpe_stream_fifo

### DIFF
--- a/rtl/fifo/hwpe_stream_fifo.sv
+++ b/rtl/fifo/hwpe_stream_fifo.sv
@@ -156,7 +156,10 @@ module hwpe_stream_fifo #(
           end
           1'b1 : begin
             ns = MIDDLE;
-            push_pointer_d = push_pointer_q + 1'b1;
+            if(push_pointer_q == FIFO_DEPTH-1)
+              push_pointer_d = '0;
+            else
+              push_pointer_d = push_pointer_q + 1'b1;
             pop_pointer_d  = pop_pointer_q;
           end
         endcase


### PR DESCRIPTION
Fixed an incorrect behavior in the In the hwpe_stream_fifo module. In the "EMPTY" state, the value of push_pointer_q was not checked, which in some situations caused the value of push_pointer_d to be greater than FIFO_DEPTH.