### PR TITLE
Fix VCS compatibility

### DIFF
--- a/Bender.yml
+++ b/Bender.yml
@@ -15,8 +15,8 @@ sources:
       # package. Files in level 1 only depend on files in level 0, files in level 2 on files in
       # levels 1 and 0, etc. Files within a level are ordered alphabetically.
       # Level 0
-      - rtl/hwpe_stream_interfaces.sv
       - rtl/hwpe_stream_package.sv
+      - rtl/hwpe_stream_interfaces.sv
       # Level 1
       - rtl/basic/hwpe_stream_assign.sv
       - rtl/basic/hwpe_stream_buffer.sv

--- a/rtl/hwpe_stream_interfaces.sv
+++ b/rtl/hwpe_stream_interfaces.sv
@@ -65,7 +65,9 @@ interface hwpe_stream_intf_tcdm (
 
 endinterface // hwpe_stream_intf_tcdm
 
-interface hwpe_stream_intf_stream (
+interface hwpe_stream_intf_stream
+  import hwpe_stream_package::*;
+(
   input logic clk
 );
   parameter int unsigned DATA_WIDTH = 32; // used to default to -1 and always overridden --> not well supported by some tools
@@ -78,7 +80,7 @@ interface hwpe_stream_intf_stream (
   logic                    valid;
   logic                    ready;
   logic [DATA_WIDTH-1:0]   data;
-  logic [STRB_WIDTH-1:0]   strb;
+  logic [hwpe_stream_package::iomsb(STRB_WIDTH):0]   strb;
 
   modport source (
     output valid, data, strb,

--- a/rtl/hwpe_stream_package.sv
+++ b/rtl/hwpe_stream_package.sv
@@ -15,6 +15,11 @@
 
 package hwpe_stream_package;
 
+  // Return either the argument minus 1 or 0 if 0; useful for IO vector width declaration
+  function automatic integer unsigned iomsb(input integer unsigned width);
+    return (width != 32'd0) ? unsigned'(width - 1) : 32'd0;
+  endfunction
+
   // realignment types
   parameter int unsigned HWPE_STREAM_REALIGN_SOURCE = 0;
   parameter int unsigned HWPE_STREAM_REALIGN_SINK   = 1;


### PR DESCRIPTION
This PR fixes the (somewhat common) slice/range underflows in logic vectors by using the `iomsb` function.
This is a requirement for simulating IPs from this package using VCS.