### PR TITLE
[SV Compliance][Slang] Fix nested comment syntax

### DIFF
--- a/rtl/fifo/hwpe_stream_fifo_passthrough.sv
+++ b/rtl/fifo/hwpe_stream_fifo_passthrough.sv
@@ -11,9 +11,9 @@
  * this License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
  * CONDITIONS OF ANY KIND, either express or implied. See the License for the
  * specific language governing permissions and limitations under the License.
- *
+ */
 
-/**
+/*
  * The **hwpe_stream_fifo_passthrough** module implements a hardware FIFO
  * queue for HWPE-Stream streams, used to withstand data scarcity (`valid`=0) or
  * backpressure (`ready`=0), decoupling two architectural domains.


### PR DESCRIPTION
Very nitpicky PR, but the System Verilog spec forbids nested block comments:
IEEE 1800-2023 Section 5.4 "Comments":

> SystemVerilog has two forms to introduce comments. A one-line comment shall start with the two
> characters // and end with a newline character. A block comment shall start with /* and end with */. **Block**
> **comments shall not be nested.** The one-line comment token // shall not have any special meaning inside a
> block comment, and the block comment tokens /* and */ shall not have any special meaning inside a one-
> line comment.

This PR fixes this in `hwpe_stream_fifo_passthrough`