### PR TITLE
Fix `hwpe_stream_fifo_passthrough` block comment

### DIFF
--- a/rtl/fifo/hwpe_stream_fifo_passthrough.sv
+++ b/rtl/fifo/hwpe_stream_fifo_passthrough.sv
@@ -11,7 +11,7 @@
  * this License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
  * CONDITIONS OF ANY KIND, either express or implied. See the License for the
  * specific language governing permissions and limitations under the License.
- *
+ */
 
 /**
  * The **hwpe_stream_fifo_passthrough** module implements a hardware FIFO


### PR DESCRIPTION
Slang says:  
```
rtl/fifo/hwpe_stream_fifo_passthrough.sv:16:1: error: nested block comments are disallowed by SystemVerilog
```

And I am inclined to believe it, so I just split the block comment in two.