### PR TITLE
Remove blocking assignment from always_latch block

### DIFF
--- a/rtl/fifo/hwpe_stream_fifo_scm.sv
+++ b/rtl/fifo/hwpe_stream_fifo_scm.sv
@@ -144,7 +144,7 @@ module hwpe_stream_fifo_scm
         for(k=0; k<NUM_WORDS; k++)
         begin : w_WordIter
             if( ClocksxC[k] == 1'b1)
-              MemContentxDP[k] = WDataIntxD;
+              MemContentxDP[k] <= WDataIntxD;
         end
     end
 


### PR DESCRIPTION
always_latch blocks should only contain blocking assignments. This PR removes the incorrect blocking assignment.